### PR TITLE
Zoom Transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,19 @@ If *scale* is specified, sets this tile layout’s scale to the specified number
 <a href="#tile_translate" name="tile_translate">#</a> <i>tile</i>.<b>translate</b>([<i>translate</i>])
 
 If *translate* is specified, sets this tile layout’s translate to the specified two-element array of numbers [*x*, *y*] and returns this tile layout. If *translate* is not specified, returns the current layout translate.
+
+<a href="#tile_transform" name="tile_transform">#</a> <i>tile</i>.<b>transform</b>([<i>transform</i>])
+
+If *transform* is specified, sets this tile layout’s scale and translate from the specified [zoom transform](https://github.com/d3/d3-zoom#zoom-transforms) and returns this tile layout. If *transform* is not specified, returns the current layout scale and translate as a transform.
+
+The following two invocations are equivalent:
+
+```js
+tile.transform(transform);
+```
+
+```js
+tile
+  .scale(transform.k)
+  .translate([transform.x, transform.y]);
+```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Computes the set of 256x256 quadtree tiles to display given the current layout [
 "http://a.tile.openstreetmap.org/" + d[2] + "/" + d[0] + "/" + d[1] + ".png"
 ```
 
-The returned array also has properties `scale` and `translate` that can be used to apply the correct transformation to an SVG G element containing the tile images where tile images have unit width and height, and *x*- and *y*-coordinates corresponding to the tile address. For example usage, see [Raster & Vector 4.0](http://bl.ocks.org/curran/e857dbe6db49d4cac379855b0b6b58e9).
+The returned array also has `scale`, `translate`, and `transform` properties that can be used to apply the correct transformation to an SVG G element containing the tile images where tile images have unit width and height, and *x*- and *y*-coordinates corresponding to the tile address. For example usage, see [Raster & Vector 4.0](http://bl.ocks.org/curran/e857dbe6db49d4cac379855b0b6b58e9).
 
 <a href="#tile_extent" name="tile_extent">#</a> <i>tile</i>.<b>extent</b>([<i>extent</i>])
 

--- a/package.json
+++ b/package.json
@@ -19,13 +19,14 @@
     "url": "https://github.com/d3/d3-tile.git"
   },
   "scripts": {
-    "pretest": "rm -rf build && mkdir build && rollup --banner \"$(preamble)\" -g d3-array:d3 -f umd -n d3 -o build/d3-tile.js -- index.js",
+    "pretest": "rm -rf build && mkdir build && rollup --banner \"$(preamble)\" -g d3-array:d3,d3-zoom:d3 -f umd -n d3 -o build/d3-tile.js -- index.js",
     "test": "tape 'test/**/*-test.js' && eslint index.js src",
     "prepublish": "npm run test && uglifyjs --preamble \"$(preamble)\" build/d3-tile.js -c -m -o build/d3-tile.min.js",
     "postpublish": "VERSION=`node -e 'console.log(require(\"./package.json\").version)'`; git push && git push --tags && cp build/d3-tile.js ../d3.github.com/d3-tile.v0.0.js && cp build/d3-tile.min.js ../d3.github.com/d3-tile.v0.0.min.js && cd ../d3.github.com && git add d3-tile.v0.0.js d3-tile.v0.0.min.js && git commit -m \"d3-tile ${VERSION}\" && git push && cd - && zip -j build/d3-tile.zip -- LICENSE README.md build/d3-tile.js build/d3-tile.min.js"
   },
   "dependencies": {
-    "d3-array": "1"
+    "d3-array": "1",
+    "d3-zoom": "^0.3.1"
   },
   "devDependencies": {
     "eslint": "2",

--- a/src/tile.js
+++ b/src/tile.js
@@ -1,4 +1,5 @@
 import {range} from "d3-array";
+import {zoomIdentity} from "d3-zoom";
 
 export default function() {
   var x0 = 0,
@@ -45,6 +46,14 @@ export default function() {
 
   tile.translate = function(_) {
     return arguments.length ? (tx = +_[0], ty = +_[1], tile) : [tx, ty];
+  };
+
+  tile.transform = function(_) {
+    if(arguments.length){
+      return tile.scale(_.k).translate([_.x, _.y]);
+    } else {
+      return zoomIdentity.translate(tx, ty).scale(scale);
+    }
   };
 
   tile.zoomDelta = function(_) {

--- a/src/tile.js
+++ b/src/tile.js
@@ -29,6 +29,11 @@ export default function() {
 
     tiles.translate = [x / k, y / k];
     tiles.scale = k;
+
+    tiles.transform = zoomIdentity
+      .scale(tiles.scale)
+      .translate(tiles.translate[0], tiles.translate[1]);
+
     return tiles;
   }
 

--- a/test/tile-test.js
+++ b/test/tile-test.js
@@ -1,7 +1,8 @@
 var tape = require("tape"),
-    d3 = require("../");
+    d3 = require("../"),
+    zoomIdentity = require("d3-zoom").zoomIdentity;
 
-tape("tile", function(test) {
+tape("core functionality", function(test) {
   var width = 960,
       height = 500,
       tile = d3.tile()
@@ -21,5 +22,24 @@ tape("tile", function(test) {
   test.deepEqual(tiles[0], [ 1, 5, 4 ]);
   test.deepEqual(tiles[1], [ 2, 5, 4 ]);
   test.deepEqual(tiles[2], [ 3, 5, 4 ]);
+  test.end();
+});
+
+tape("tile.transform", function(test) {
+  var width = 960,
+      height = 500,
+      transform = zoomIdentity
+        .translate(1617, 747)
+        .scale(4096),
+      tile = d3.tile()
+        .size([width, height])
+        .transform(transform),
+      tiles = tile();
+
+  test.deepEqual(tile.transform(), transform);
+
+  test.equal(tile.scale(), 4096);
+  test.deepEqual(tile.translate(), [1617, 747]);
+
   test.end();
 });

--- a/test/tile-test.js
+++ b/test/tile-test.js
@@ -43,3 +43,17 @@ tape("tile.transform", function(test) {
 
   test.end();
 });
+
+tape("tiles.transform", function(test) {
+  var width = 960,
+      height = 500,
+      tile = d3.tile()
+        .size([width, height])
+        .scale(4096)
+        .translate([1617, 747]),
+      tiles = tile();
+  test.deepEqual(tiles.transform, zoomIdentity
+    .scale(256)
+    .translate(-1.68359375, -5.08203125));
+  test.end();
+});


### PR DESCRIPTION
This PR takes advantage of [zoom transforms](https://github.com/d3/d3-zoom#zoom-transforms) to make the tile API easier to work with.

Closes:

 * #4 <i>tile</i>.<b>transform</b>([<i>transform</i>])
 * #5 `tiles.transform`

Here's a [complete working example demonstrating this new API](http://bl.ocks.org/curran/defa669c2e7935a91ef5457fe5dd3bc2).
### Pros

 * A cleaner API when working with d3-zoom.

Before:

```js
var tiles = tile
  .scale(transform.k)
  .translate([transform.x, transform.y])
  ();
...
raster.attr("transform", "scale(" + tiles.scale + ")translate(" + tiles.translate + ")");
```

After:

```js
var tiles = tile.transform(transform)();
...
raster.attr("transform", tiles.transform);
```

### Cons

 * An additional dependency on d3-zoom. Not sure if this is really a con, but adding a dependency feels like a step not to be taken lightly. This is a win for the modular approach though - it feels much better to add d3-zoom as a dependency here rather than to d3-geo.

### Open questions

Now that there is a `transform` property on the returned `tiles` array, should its properties `scale` and `translate` be removed? Or is there some value in leaving the unscaled translation exposed?