### PR TITLE
[Experimental] Transform (small API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Constructs a layout for determining which 256x256 quadtree tiles to display in a
 var tile = d3.tile();
 ```
 
-<a href="#_tile" name="_tile">#</a> <i>tile</i>()
+<a href="#_tile" name="_tile">#</a> <i>tile</i>(transform)
 
-Computes the set of 256x256 quadtree tiles to display given the current layout [extent](#tile_extent), [scale](#tile_scale) and [translate](#tile_translate). Returns an array of arrays that specify tile addresses as [*x*, *y*, *z*] where *z* is the zoom level. For example, the address of a tile from OpenStreetMap can be computed as follows, where *d* is an entry in the returned array.
+Computes the set of 256x256 quadtree tiles to display given the current layout [extent](#tile_extent) and the specified *[transform](https://github.com/d3/d3-zoom#zoom-transforms)*. Returns an array of arrays that specify tile addresses as [*x*, *y*, *z*] where *z* is the zoom level. For example, the address of a tile from OpenStreetMap can be computed as follows, where *d* is an entry in the returned array.
 
 ```js
 "http://a.tile.openstreetmap.org/" + d[2] + "/" + d[0] + "/" + d[1] + ".png"
@@ -72,11 +72,3 @@ If *extent* is specified, sets this tile layout’s extent to the specified arra
 <a href="#tile_size" name="tile_size">#</a> <i>tile</i>.<b>size</b>([<i>size</i>])
 
 If *size* is specified, sets this tile layout’s size to the specified two-element array of numbers [*width*, *height*] and returns this tile layout. If *size* is not specified, returns the current layout size. This is a convenience method equivalent to setting the [extent](#tile_extent) to [[0, 0], [*width*, *height*]].
-
-<a href="#tile_scale" name="tile_scale">#</a> <i>tile</i>.<b>scale</b>([<i>scale</i>])
-
-If *scale* is specified, sets this tile layout’s scale to the specified number *scale* and returns this tile layout. If *scale* is not specified, returns the current layout scale.
-
-<a href="#tile_translate" name="tile_translate">#</a> <i>tile</i>.<b>translate</b>([<i>translate</i>])
-
-If *translate* is specified, sets this tile layout’s translate to the specified two-element array of numbers [*x*, *y*] and returns this tile layout. If *translate* is not specified, returns the current layout translate.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "d3-array": "1"
   },
   "devDependencies": {
+    "d3-zoom": "^1.0.0",
     "eslint": "2",
     "package-preamble": "0.0",
     "rollup": "0.31",

--- a/src/tile.js
+++ b/src/tile.js
@@ -9,15 +9,11 @@ export default function() {
 
   function tile(t) {
 
-    var scale = t.k,
-        tx = t.x,
-        ty = t.y,
-
-        z = Math.max(Math.log(scale) / Math.LN2 - 8, 0),
+    var z = Math.max(Math.log(t.k) / Math.LN2 - 8, 0),
         z0 = Math.round(z + zoomDelta),
         k = Math.pow(2, z - z0 + 8),
-        x = tx - scale / 2,
-        y = ty - scale / 2,
+        x = t.x - t.k / 2,
+        y = t.y - t.k / 2,
         tiles = [],
         cols = range(Math.max(0, Math.floor((x0 - x) / k)), Math.max(0, Math.ceil((x1 - x) / k))),
         rows = range(Math.max(0, Math.floor((y0 - y) / k)), Math.max(0, Math.ceil((y1 - y) / k)));

--- a/src/tile.js
+++ b/src/tile.js
@@ -5,13 +5,15 @@ export default function() {
       y0 = 0,
       x1 = 960,
       y1 = 500,
-      tx = (x0 + x1) / 2,
-      ty = (y0 + y1) / 2,
-      scale = 256,
       zoomDelta = 0;
 
-  function tile() {
-    var z = Math.max(Math.log(scale) / Math.LN2 - 8, 0),
+  function tile(t) {
+
+    var scale = t.k,
+        tx = t.x,
+        ty = t.y,
+
+        z = Math.max(Math.log(scale) / Math.LN2 - 8, 0),
         z0 = Math.round(z + zoomDelta),
         k = Math.pow(2, z - z0 + 8),
         x = tx - scale / 2,
@@ -37,14 +39,6 @@ export default function() {
 
   tile.extent = function(_) {
     return arguments.length ? (x0 = +_[0][0], y0 = +_[0][1], x1 = +_[1][0], y1 = +_[1][1], tile) : [[x0, y0], [x1, y1]];
-  };
-
-  tile.scale = function(_) {
-    return arguments.length ? (scale = +_, tile) : scale;
-  };
-
-  tile.translate = function(_) {
-    return arguments.length ? (tx = +_[0], ty = +_[1], tile) : [tx, ty];
   };
 
   tile.zoomDelta = function(_) {

--- a/test/tile-test.js
+++ b/test/tile-test.js
@@ -1,18 +1,18 @@
 var tape = require("tape"),
-    d3 = require("../");
+    d3 = require("../"),
+    zoomIdentity = require("d3-zoom").zoomIdentity;
 
 tape("tile", function(test) {
   var width = 960,
       height = 500,
       tile = d3.tile()
-        .size([width, height])
-        .scale(4096)
-        .translate([1617, 747]),
-      tiles = tile();
+        .size([width, height]),
+      transform = zoomIdentity
+        .translate(1617, 747)
+        .scale(4096),
+      tiles = tile(transform);
 
   test.deepEqual(tile.size(), [width, height]);
-  test.equal(tile.scale(), 4096);
-  test.deepEqual(tile.translate(), [1617, 747]);
 
   test.equal(tiles.scale, 256);
   test.equal(tiles.translate[0], -1.68359375);


### PR DESCRIPTION
This PR implements the idea described by @mbostock in tile.transform #4, resulting in both a smaller API and a simpler way to invoke the tile layout when working with d3-zoom.
- Replaces <i>tile</i>() by <i>tile</i>(transform)
- Removes <i>tile</i>.<b>scale</b>([<i>scale</i>]) and <i>tile</i>.<b>translate</b>([<i>translate</i>])

Before:

``` js
var tiles = tile
  .scale(transform.k)
  .translate([transform.x, transform.y])
  ();
```

After:

``` js
var tiles = tile(transform);
```
