### PR TITLE
Complete unpkg migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A layout for working with image-based map tiles. This can be used to create a si
 
 ## Installing
 
-If you use NPM, `npm install d3-tile`. Otherwise, download the [latest release](https://github.com/d3/d3-tile/releases/latest). You can also load directly from [d3js.org](https://d3js.org) as a [standalone library](https://d3js.org/d3-tile.v0.0.min.js). AMD, CommonJS, and vanilla environments are supported. In vanilla, a `d3` global is exported:
+If you use NPM, `npm install d3-tile`. Otherwise, download the [latest release](https://github.com/d3/d3-tile/releases/latest). You can also load directly from [unpkg.com](https://unpkg.com) as a [standalone library](https://unpkg.com/d3-tile@0.0). AMD, CommonJS, and vanilla environments are supported. In vanilla, a `d3` global is exported:
 
 ```html
 <script src="https://unpkg.com/d3-array@1.0"></script>


### PR DESCRIPTION
Updates a few leftover references to d3js.org to point to unpkg.